### PR TITLE
change "frenchb" to "french"

### DIFF
--- a/content/resume_fr/resume_fr_master.tex
+++ b/content/resume_fr/resume_fr_master.tex
@@ -1,6 +1,6 @@
 % !TEX root = ../content.tex
 
-\begin{otherlanguage}{frenchb}
+\begin{otherlanguage}{french}
 \chapternoquote*{Résumé en Français} % (fold)
 \label{cha:resume_fr}
 \addstarredchapter{\nameref{cha:resume_fr}} % for minitoc in a starred chapter


### PR DESCRIPTION
With value `frenchb` the following error appeared:

```
(./content/resume_fr/resume_fr_master.tex

! Package babel Error: Unknown language `frenchb'. Either you have
(babel)                misspelled its name, it has not been installed,
(babel)                or you requested it in a previous run. Fix its name,
(babel)                install it or just rerun the file, respectively.

See the babel package documentation for explanation.
Type  H <return>  for immediate help.
 ...                                              
                                                  
l.3 \begin{otherlanguage}{frenchb}
```